### PR TITLE
feat: configure Axios base instance with interceptors

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+});
+
+api.interceptors.request.use((config) => {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
+});
+
+api.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    const message =
+      error.response?.data?.message ?? error.message ?? "An error occurred";
+    return Promise.reject(new Error(message));
+  }
+);
+
+export default api;


### PR DESCRIPTION
Closes #2

## Changes
- Creates `src/services/api.ts` exporting a configured Axios instance
- Base URL read from `NEXT_PUBLIC_API_URL` env variable
- Request interceptor attaches `Bearer` token from `localStorage` when present
- Response interceptor normalises errors into a single `Error` with a human-readable message