### PR TITLE
Add an optional signal parameter to both functions on transactionService

### DIFF
--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -1,12 +1,28 @@
 import api from './api';
 import type { Transaction, SendMoneyPayload } from '@/types';
 
-export async function sendMoney(payload: SendMoneyPayload): Promise<Transaction> {
-  const { data } = await api.post<Transaction>('/transactions', payload);
+/**
+ * Sends money to a specific recipient address.
+ * 
+ * @param payload - The transaction payload containing recipient, amount, and asset type.
+ * @param signal - Optional AbortSignal to cancel the request if the component unmounts.
+ * @returns A promise that resolves to the newly created Transaction record.
+ */
+export async function sendMoney(
+  payload: SendMoneyPayload,
+  signal?: AbortSignal
+): Promise<Transaction> {
+  const { data } = await api.post<Transaction>('/transactions', payload, { signal });
   return data;
 }
 
-export async function getTransactions(): Promise<Transaction[]> {
-  const { data } = await api.get<Transaction[]>('/transactions');
+/**
+ * Retrieves the transaction history for the authenticated user.
+ * 
+ * @param signal - Optional AbortSignal to cancel the request if the component unmounts.
+ * @returns A promise that resolves to an array of Transaction records.
+ */
+export async function getTransactions(signal?: AbortSignal): Promise<Transaction[]> {
+  const { data } = await api.get<Transaction[]>('/transactions', { signal });
   return data;
 }


### PR DESCRIPTION
changes made 

AbortSignal Support: I added an optional signal parameter to both functions. This is incredibly useful for frontend apps because it allows you to cancel the HTTP request if the user navigates away from the page before the request completes, which prevents memory leaks and strange race-condition bugs.


JSDoc Comments: I've added comprehensive documentation for the functions so that when you hover over them in your editor (VS Code, etc.), it will describe what the functions do, their arguments, and their return types.