### PR TITLE
feat: build reusable Table component

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,0 +1,59 @@
+interface TableProps<T> {
+  columns: { key: keyof T; label: string }[];
+  data: T[];
+  loading?: boolean;
+}
+
+export default function Table<T extends { id?: string | number }>({
+  columns,
+  data,
+  loading = false,
+}: TableProps<T>) {
+  return (
+    <div className="overflow-x-auto w-full">
+      <table className="min-w-full text-sm text-left text-gray-700">
+        <thead className="bg-gray-100 text-gray-600 uppercase text-xs">
+          <tr>
+            {columns.map((col) => (
+              <th key={String(col.key)} className="px-4 py-3 font-medium">
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            Array.from({ length: 5 }).map((_, i) => (
+              <tr key={i} className="border-t border-gray-200 animate-pulse">
+                {columns.map((col) => (
+                  <td key={String(col.key)} className="px-4 py-3">
+                    <div className="h-4 bg-gray-200 rounded w-3/4" />
+                  </td>
+                ))}
+              </tr>
+            ))
+          ) : data.length === 0 ? (
+            <tr>
+              <td
+                colSpan={columns.length}
+                className="px-4 py-8 text-center text-gray-400"
+              >
+                No data available.
+              </td>
+            </tr>
+          ) : (
+            data.map((row, i) => (
+              <tr key={row.id ?? i} className="border-t border-gray-200 hover:bg-gray-50">
+                {columns.map((col) => (
+                  <td key={String(col.key)} className="px-4 py-3">
+                    {String(row[col.key] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements the generic `Table` component as specified in #14.

## Changes
- Added `src/components/Table.tsx` with `TableProps<T>` interface
- Skeleton rows (5) with `animate-pulse` shown when `loading={true}`
- Empty state message when `data` is empty
- Responsive horizontal scroll via `overflow-x-auto`

## Closes
Closes #14