### PR TITLE
feat: build FormInput component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "14.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.78.0",
         "react-hot-toast": "^2.4.1",
         "stellar-sdk": "^13.3.0",
         "zod": "^3.23.8",
@@ -4620,6 +4621,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.78.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.78.0.tgz",
+      "integrity": "sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-hot-toast": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
@@ -9200,6 +9217,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       }
+    },
+    "react-hook-form": {
+      "version": "7.78.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.78.0.tgz",
+      "integrity": "sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==",
+      "requires": {}
     },
     "react-hot-toast": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "14.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.78.0",
     "react-hot-toast": "^2.4.1",
     "stellar-sdk": "^13.3.0",
     "zod": "^3.23.8",

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { UseFormRegister, FieldValues } from 'react-hook-form';
+
+export interface FormInputProps {
+  label: string;
+  name: string;
+  type?: string;
+  placeholder?: string;
+  error?: string;
+  register: UseFormRegister<FieldValues>;
+}
+
+export default function FormInput({
+  label,
+  name,
+  type = 'text',
+  placeholder,
+  error,
+  register,
+}: FormInputProps) {
+  const inputId = `form-input-${name}`;
+  const errorId = `form-input-error-${name}`;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={inputId}
+        className="text-sm font-medium text-gray-700"
+      >
+        {label}
+      </label>
+
+      <input
+        id={inputId}
+        type={type}
+        placeholder={placeholder}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
+        className={`
+          w-full px-3 py-2.5 rounded-lg border text-sm text-gray-900
+          placeholder:text-gray-400
+          transition-colors duration-150
+          focus:outline-none focus:ring-2 focus:ring-brand focus:border-brand
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${
+            error
+              ? 'border-red-400 focus:ring-red-400 focus:border-red-400'
+              : 'border-gray-300'
+          }
+        `}
+        {...register(name)}
+      />
+
+      {error && (
+        <p id={errorId} className="text-xs text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a reusable `FormInput` component with full react-hook-form integration.

## Props

| Prop | Type | Required | Description |
|------|------|----------|-------------|
| `label` | `string` | Yes | Label text displayed above the input |
| `name` | `string` | Yes | Form field name, passed to react-hook-form register |
| `type` | `string` | No | HTML input type (default: `text`) |
| `placeholder` | `string` | No | Placeholder text |
| `error` | `string` | No | Validation error message, shown in red below input |
| `register` | `UseFormRegister<FieldValues>` | Yes | react-hook-form register function |

## Features

- **Label above input** — clearly associated via `htmlFor`/`id`
- **Error display** — red error message below the input with `role="alert"` for screen readers
- **Tailwind styling** — focus ring (`ring-2 ring-brand`), consistent border colors, smooth transitions
- **Accessibility** — `aria-invalid`, `aria-describedby` linking to error, proper label association
- **Error border state** — border turns red when error is present, with red focus ring

## Usage

```tsx
import { useForm } from 'react-hook-form';
import FormInput from '@/components/FormInput';

function MyForm() {
  const { register, formState: { errors } } = useForm();
  
  return (
    <form>
      <FormInput
        label=Email
        name=email
        type=email
        placeholder=you@example.com
        register={register}
        error={errors.email?.message}
      />
    </form>
  );
}
```

## Changes

- Create `src/components/FormInput.tsx`
- Install `react-hook-form` dependency

Closes #15